### PR TITLE
Allow canonical_base to contain a path

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const _			= {
 	defaultsDeep: require('lodash.defaultsdeep'),
 	findIndex		: require('lodash.findindex'),
 	isEmpty			: require('lodash.isempty'),
+	trimStart: require('lodash.trimstart'),
+	trimEnd: require('lodash.trimend')
 };
 
 // -----------------------------------------------------------------------------
@@ -23,8 +25,8 @@ const PLUGIN = {
 
 // -----------------------------------------------------------------------------
 
-const resolveURL = (base, path) =>
-	(base.endsWith('/') ? base.slice(0, -1) : base) + path;
+const resolveURL = ( base, path ) =>
+	`${_.trimEnd( base, '/' )}/${_.trimStart( path, '/' )}`
 
 /**
  * @return {object}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const URL		= require('url');
 const _			= {
 	defaultsDeep: require('lodash.defaultsdeep'),
 	findIndex		: require('lodash.findindex'),
@@ -23,6 +22,9 @@ const PLUGIN = {
 };
 
 // -----------------------------------------------------------------------------
+
+const resolveURL = (base, path) =>
+	(base.endsWith('/') ? base.slice(0, -1) : base) + path;
 
 /**
  * @return {object}
@@ -53,7 +55,7 @@ PLUGIN.get_options_defaults = () =>
 		//
 		// having only started with vuepress a few days ago, 
 		// so far, i couldn't figure out a proper way to extend config head
-		// and add <link rel="canonical" href="URL.resolve( canonical_base, $page.path )">
+		// and add <link rel="canonical" href="resolveURL( canonical_base, $page.path )">
 
 		// -------------------------------------------------------------------------
 		
@@ -240,8 +242,6 @@ PLUGIN.is_url = ( maybe_url ) =>
 }
 // PLUGIN.is_url()
 
-
-
 /**
  * @return {string}
  */
@@ -250,7 +250,7 @@ PLUGIN.get_canonical_url = ( $page, options ) =>
 	
 	if ( options.canonical_base && $page.path )
 	{
-		return URL.resolve( options.canonical_base, $page.path );
+		return resolveURL( options.canonical_base, $page.path );
 	}
 	
 };
@@ -496,7 +496,7 @@ PLUGIN.get_default_image_url = ( $page, options ) =>
 		
 		if ( options.canonical_base )
 		{
-			out = URL.resolve( options.canonical_base, out );
+			out = resolveURL( options.canonical_base, out );
 			
 			return out;
 		}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "lodash.defaultsdeep": "4.6.1",
     "lodash.findindex": "4.6.0",
     "lodash.isempty": "4.4.0",
+    "lodash.trimend": "^4.5.1",
+    "lodash.trimstart": "^4.5.1",
     "remove-markdown": "0.3.0",
     "striptags": "3.1.1"
   },


### PR DESCRIPTION
<!-- please provide a general summary of your changes in the title above -->


## Description

Hi! Thanks for this plugin, very handy and powerful.

My use case is that I have a VuePress site served at a `base` URL path, for example `https://example.com/blog`. If I use `https://example.com/blog` as the `canonical_base`, URLs in `twitter:url` and `og:url` aren't correctly rendered. More specifically, a page whose path is `/some/path` is rendered as `https://example.com/some/path`, instead of `https://example.com/blog/some/path`.

This is because of [how `URL.resolve` works](https://nodejs.org/api/url.html#url_url_resolve_from_to):

```js
> URL.resolve("https://example.com/blog", "/some/path")
"https://example.com/some/path"
```

This PR changes the resolution of the canonical URL to simply concatenating `canonical_base` with `$page.path`, taking care to never use two slashes in between.

## Checklist

<!-- put an `x` in all the boxes that apply -->

- [ ] All tests are passing
- [ ] My code follows the code style and structure of this project

(I didn't check these since I didn't find the test files or guidelines on code style.)